### PR TITLE
Add minItems property

### DIFF
--- a/release-schema.json
+++ b/release-schema.json
@@ -6,6 +6,7 @@
           "title": "Contract signatories",
           "description": "The signatories to the contract. Each signatory should have an associated entry in the parties section of OCDS.",
           "type": "array",
+		  "minItems": 2,
           "items": {
             "$ref": "#/definitions/OrganizationReference"
           },


### PR DESCRIPTION
Ref https://github.com/open-contracting/ocds-extensions/issues/102

Using `"minItems": 2` since a contract should have at least two signatures. 